### PR TITLE
tools: rinaperf: add timestamp option for ping test

### DIFF
--- a/user/tools/rinaperf.c
+++ b/user/tools/rinaperf.c
@@ -171,6 +171,7 @@ struct rinaperf {
     int duration;           /* duration of client test (secs) */
     int use_mss_size;       /* use flow MSS as packet size */
     int verbose;            /* be verbose */
+    int timestamp;          /* print timestamp during ping test */
     int stop_pipe[2];       /* to stop client threads */
     int cli_stop;           /* another way to stop client threads */
     int cli_flow_allocated; /* client flows allocated ? */
@@ -317,6 +318,14 @@ ping_client(struct worker *w)
                     clock_gettime(CLOCK_MONOTONIC, &t2);
                     ns = 1000000000 * (t2.tv_sec - t1.tv_sec) +
                          (t2.tv_nsec - t1.tv_nsec);
+                    if (w->rp->timestamp) {
+                        struct timeval recv_time;
+                        gettimeofday(&recv_time, NULL);
+                        PRINTF("[%lu.%06lu] ",
+                           (unsigned long)recv_time.tv_sec,
+                           (unsigned long)recv_time.tv_usec
+                        );
+                    }
                     PRINTF("%d bytes from server: rtt = %.3f ms\n", ret,
                            ((float)ns) / 1000000.0);
                 } else {
@@ -1401,6 +1410,8 @@ usage(void)
         "   -L NUM : maximum loss probability introduced by the flow "
         "(NUM/%u)\n"
         "   -E NUM : maximum delay introduced by the flow (microseconds)\n"
+        "   -T : print timestamp (unix time + microseconds as in gettimeofday) "
+        "before each line in ping test\n"
         "   -v : be verbose\n",
         RINA_FLOW_SPEC_LOSS_MAX);
 }
@@ -1434,6 +1445,7 @@ main(int argc, char **argv)
     rp->duration      = 0;
     rp->use_mss_size  = 1;
     rp->verbose       = 0;
+    rp->timestamp     = 0;
     rp->cfd           = -1;
     rp->stop_pipe[0] = rp->stop_pipe[1] = -1;
     rp->cli_stop = rp->cli_flow_allocated = 0;
@@ -1445,7 +1457,7 @@ main(int argc, char **argv)
     /* Start with a default flow configuration (unreliable flow). */
     rina_flow_spec_unreliable(&rp->flowspec);
 
-    while ((opt = getopt(argc, argv, "hlt:d:c:s:i:B:g:b:a:z:p:D:L:E:wv")) !=
+    while ((opt = getopt(argc, argv, "hlt:d:c:s:i:B:g:b:a:z:p:D:L:E:Twv")) !=
            -1) {
         switch (opt) {
         case 'h':
@@ -1538,6 +1550,10 @@ main(int argc, char **argv)
 
         case 'v':
             rp->verbose = 1;
+            break;
+
+        case 'T':
+            rp->timestamp = 1;
             break;
 
         case 'L':


### PR DESCRIPTION
The timestamp option is as ping -D. 
The need came from ARCFIRE experiments.